### PR TITLE
Fix `instance` and add better overwrite behaviour

### DIFF
--- a/lib/rspec/arguments/arguments.rb
+++ b/lib/rspec/arguments/arguments.rb
@@ -20,17 +20,11 @@ module RSpec
 
       return call_method_with_args(clazz, class_method.to_sym) if class_method
 
-      process_instance_subject(clazz)
+      process_instance_subject
     end
 
-    def process_instance(clazz)
-      __memoized.fetch_or_store(:instance) do
-        call_initializer_with_args(clazz)
-      end
-    end
-
-    def process_instance_subject(clazz)
-      instance = process_instance(clazz)
+    def process_instance_subject
+      instance = self.instance
 
       method = method_under_test(:method)
 
@@ -93,9 +87,16 @@ module RSpec
 
     def search_method_name(metadata, key)
       description = metadata[:description]
+
+      return description if potential_method?(description)
       return description unless metadata[:parent_example_group] && metadata[:parent_example_group][key]
 
       search_method_name(metadata[:parent_example_group], key) if metadata[:parent_example_group]
+    end
+
+    def potential_method?(str)
+      c = str[0]
+      c == '#' || c == '.'
     end
 
     def call_initializer_with_args(receiver)

--- a/lib/rspec/arguments/example_group.rb
+++ b/lib/rspec/arguments/example_group.rb
@@ -56,6 +56,24 @@ module RSpec
         _arg_block(METHOD_BLOCK_ARG, name, &block)
       end
 
+      def instance(name = nil, &block)
+        if name
+          let(name, &block)
+          alias_method :instance, name
+
+          self::NamedSubjectPreventSuper.__send__(:define_method, name) do
+            raise NotImplementedError, "`super` in named instances is not supported"
+          end
+        else
+          let(:instance, &block)
+        end
+      end
+
+      def instance!(name = nil, &block)
+        instance(name, &block)
+        before { instance }
+      end
+
       private
 
       def _arg(positional_arg, keyword_arg, name, position = nil, &block)

--- a/lib/rspec/arguments/monkey_patcher.rb
+++ b/lib/rspec/arguments/monkey_patcher.rb
@@ -39,7 +39,7 @@ module RSpec
             if metadata[:rspec_arguments] || metadata[:method] || metadata[:class_method]
               raise 'Instance is only available when testing class instances or instance methods' if metadata[:class_method]
 
-              process_instance(described)
+              call_initializer_with_args(described)
             else
               described.new
             end

--- a/lib/rspec/arguments/version.rb
+++ b/lib/rspec/arguments/version.rb
@@ -2,6 +2,6 @@
 
 module RSpec
   module Arguments
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end

--- a/spec/rspec/arguments_spec.rb
+++ b/spec/rspec/arguments_spec.rb
@@ -79,6 +79,22 @@ RSpec.describe C do
         expect(self).to receive(:process_subject).never
         expect(instance).to eq(described_class.new(:arg_0, kwarg: :kw_value, &block))
       end
+
+      describe 'with explicit `instance` declaration' do
+        it_behaves_like :simple_method_args
+
+        instance { described_class.new(1, kwarg: 1) }
+
+        it 'instance should have expected value' do
+          expect(instance).to eq(described_class.new(1, kwarg: 1))
+        end
+      end
+
+      describe 'overriding :method' do
+        context '#wrong_method', :method do
+          it { is_expected.to eq(:wrong_method) }
+        end
+      end
     end
 
     context '.class_method', :class_method do


### PR DESCRIPTION
> Fixes https://github.com/wealthsimple/rspec-arguments/issues/5

Make `instance` a true first-class citizen, similar to `subject`.
This drops the requirement for eager initialization of it (no need for `let!`).

This PR also changes the overwriting behaviour on nested tests, allowing:

```ruby
context '#m1', :method do
  context '#m2', :method do
    it { is_expected.to eq(:m2_return_value) }
  end
end
```

to bind `:method` to the inner-most example group.